### PR TITLE
Use spring-boot-parent as a bom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,37 +32,17 @@
 
   <properties>
     <postgresql.version>9.4.1212</postgresql.version>
-    <rest-assured.version>2.9.0</rest-assured.version>
     <spring-boot.version>1.4.1.RELEASE</spring-boot.version>
-    <!-- https://issues.jboss.org/browse/KEYCLOAK-3669 -->
-    <tomcat.version>8.5.4</tomcat.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>${spring-boot.version}</version>
+        <groupId>org.jboss.snowdrop</groupId>
+        <artifactId>spring-boot-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-
-      <!-- Override Tomcat version -->
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
-        <version>${tomcat.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-el</artifactId>
-        <version>${tomcat.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-websocket</artifactId>
-        <version>${tomcat.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -90,12 +70,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.jayway.restassured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <version>${rest-assured.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Verified with booster's integration tests. This should be merged when the new version of spring-boot-parent is released.