### PR TITLE
Adding Spring Developer tools dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,13 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+   
+    <!-- Spring Boot Developer Tools -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-devtools</artifactId>
+        <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Issue https://github.com/snowdrop/spring-boot-crud-booster/issues/18
Upstream issue - https://github.com/redhat-developer/rh-che/issues/254

![image](https://user-images.githubusercontent.com/1461122/34167885-591b69ac-e4e3-11e7-9cf0-7a040d892898.png)

This is required for enabling auto redeployment on osio:

![spring-boot-hot-deployment](https://user-images.githubusercontent.com/1461122/31444126-92e2983c-ae9b-11e7-9971-ac452797f57e.gif)
