### PR TITLE
Conditionally replace database name in UI according to build profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,18 @@
         </configuration>
       </plugin>
     </plugins>
+    <!-- Used only to replace ${db.name} in index.html with the corresponding Database name -->
+    <resources>
+        <resource>
+            <directory>src/main/resources</directory>
+            <filtering>false</filtering>
+        </resource>
+        <resource>
+            <directory>src/main/resources/static</directory>
+            <filtering>true</filtering>
+            <targetPath>static</targetPath>
+        </resource>
+    </resources>
   </build>
 
   <profiles>
@@ -113,6 +125,9 @@
           <scope>runtime</scope>
         </dependency>
       </dependencies>
+      <properties>
+          <db.name>H2</db.name>
+      </properties>
     </profile>
     <profile>
       <id>openshift</id>
@@ -124,6 +139,9 @@
           <scope>runtime</scope>
         </dependency>
       </dependencies>
+      <properties>
+          <db.name>PostgreSQL</db.name>
+      </properties>
     </profile>
     <profile>
       <id>openshift-it</id>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -115,7 +115,7 @@
     <h1>CRUD Mission - Spring Boot</h1>
     <p>
         This application demonstrates how a Spring Boot application implements a CRUD endpoint to manage <em>fruits</em>.
-        This management interface invokes the CRUD service endpoint, that interact with a PosgreSQL database using JDBC.
+        This management interface invokes the CRUD service endpoint, that interact with a ${db.name} database using JDBC.
     </p>
 
     <h3>Add/Edit a fruit</h3>


### PR DESCRIPTION
This change allows the UI to display that the application is using an
H2 database when built using the local profile. This is useful for
people running the application in standalone mode with

`mvn spring-boot:run -Plocal`.

When application is deployed to Openshift via

`mvn clean fabric8:deploy -Popenshift`,

the UI displays that a PostgreSQL database is being used.

This PR obviously does not provide any new functionality, it's simply a nicety
  